### PR TITLE
odoo-install.sh name is wrong

### DIFF
--- a/Chapter01/README.md
+++ b/Chapter01/README.md
@@ -11,11 +11,11 @@ wget https://raw.githubusercontent.com/alanhou/odoo12-cookbook/master/Chapter01/
 
 #### 2. Make the script executable
 ```
-sudo chmod +x odoo_install.sh
+sudo chmod +x odoo-install.sh
 ```
 ##### 3. Execute the script:
 ```
-sudo ./odoo_install.sh
+sudo ./odoo-install.sh
 ```
 
 ##### 4. Stop all Odoo proccesses: 


### PR DESCRIPTION
脚本名字的下划线更正